### PR TITLE
Fix usage of input flags in run command

### DIFF
--- a/cmd/pgreplay/main.go
+++ b/cmd/pgreplay/main.go
@@ -144,11 +144,11 @@ func main() {
 
 		var items chan pgreplay.Item
 
-		switch checkSingleFormat(filterJsonInput, filterErrlogInput) {
-		case filterJsonInput:
-			items = parseLog(*filterJsonInput, pgreplay.ParseJSON)
-		case filterErrlogInput:
-			items = parseLog(*filterErrlogInput, pgreplay.ParseErrlog)
+		switch checkSingleFormat(runJsonInput, runErrlogInput) {
+		case runJsonInput:
+			items = parseLog(*runJsonInput, pgreplay.ParseJSON)
+		case runErrlogInput:
+			items = parseLog(*runErrlogInput, pgreplay.ParseErrlog)
 		}
 
 		stream, err := pgreplay.NewStreamer(start, finish).Stream(items, *runReplayRate)


### PR DESCRIPTION
Use the JSON input and errlog input flags defined under the run command,
rather than those on the filter command, as these will be empty when
executing `pgreplay run`.