### PR TITLE
Remove pending work check

### DIFF
--- a/cmd/pgreplay/main.go
+++ b/cmd/pgreplay/main.go
@@ -37,15 +37,14 @@ var (
 	filterOutput      = filter.Flag("output", "JSON output file").String()
 	filterNullOutput  = filter.Flag("null-output", "Don't output anything, for testing parsing only").Bool()
 
-	run             = app.Command("run", "Replay from log files against a real database")
-	runHost         = run.Flag("host", "PostgreSQL database host").Required().String()
-	runPort         = run.Flag("port", "PostgreSQL database port").Default("5432").Uint16()
-	runDatname      = run.Flag("database", "PostgreSQL root database").Default("postgres").String()
-	runUser         = run.Flag("user", "PostgreSQL root user").Default("postgres").String()
-	runReplayRate   = run.Flag("replay-rate", "Rate of playback, will execute queries at Nx speed").Default("1").Float()
-	runPollInterval = run.Flag("poll-interval", "Interval between polling for finish").Default("5s").Duration()
-	runErrlogInput  = run.Flag("errlog-input", "Path to PostgreSQL errlog").ExistingFile()
-	runJsonInput    = run.Flag("json-input", "Path to preprocessed pgreplay JSON log file").ExistingFile()
+	run            = app.Command("run", "Replay from log files against a real database")
+	runHost        = run.Flag("host", "PostgreSQL database host").Required().String()
+	runPort        = run.Flag("port", "PostgreSQL database port").Default("5432").Uint16()
+	runDatname     = run.Flag("database", "PostgreSQL root database").Default("postgres").String()
+	runUser        = run.Flag("user", "PostgreSQL root user").Default("postgres").String()
+	runReplayRate  = run.Flag("replay-rate", "Rate of playback, will execute queries at Nx speed").Default("1").Float()
+	runErrlogInput = run.Flag("errlog-input", "Path to PostgreSQL errlog").ExistingFile()
+	runJsonInput   = run.Flag("json-input", "Path to preprocessed pgreplay JSON log file").ExistingFile()
 )
 
 func main() {
@@ -157,7 +156,6 @@ func main() {
 		}
 
 		errs, consumeDone := database.Consume(stream)
-		poller := time.NewTicker(*runPollInterval)
 
 		var status int
 
@@ -174,12 +172,6 @@ func main() {
 
 				logger.Log("event", "consume.finished", "error", err, "status", status)
 				os.Exit(status)
-
-			// Poll our consumer to determine how much work remains
-			case <-poller.C:
-				if connections, items := database.Pending(); connections > 0 {
-					logger.Log("event", "consume.pending", "connections", connections, "items", items)
-				}
 			}
 		}
 	}

--- a/pkg/pgreplay/database.go
+++ b/pkg/pgreplay/database.go
@@ -132,23 +132,6 @@ func (d *Database) Connect(item Item) (*Conn, error) {
 	return &Conn{conn, channels.NewInfiniteChannel(), sync.Once{}}, nil
 }
 
-// Pending returns a count of the connections that are still active, and how many items
-// are currently pending against all connections.
-//
-// There is a small risk that calling this function could result in a segfault, as Golang
-// maps aren't race-safe with concurrent writes and reads. The alternative implementation
-// is a lot messier though, so let's do this until there become problems.
-func (d *Database) Pending() (connections, items int) {
-	for _, conn := range d.conns {
-		if conn.IsAlive() {
-			connections++
-			items += conn.Len()
-		}
-	}
-
-	return
-}
-
 // Conn represents a single database connection handling a stream of work Items
 type Conn struct {
 	*pgx.Conn


### PR DESCRIPTION
The small risk of Go runtime panic that was called out in the comments
was biting in practice. Rather than wrap the map in a mutex (e.g. by
using a *sync.Map), we instead remove the feature altogether.