### PR TITLE
Fix on csv parser

### DIFF
--- a/pkg/pgreplay/parse.go
+++ b/pkg/pgreplay/parse.go
@@ -92,7 +92,6 @@ func ParseCsvLog(csvlog io.Reader) (items chan Item, errs chan error, done chan 
 			if err != nil {
 				logLinesErrorTotal.Inc()
 				errs <- err
-				continue
 			}
 
 			item, err := ParseCsvItem(logline, unbounds, parsebuffer)


### PR DESCRIPTION
hi @chill, sorry but I noticed an error on my last PR that you merged 😆.

On my last commit I got introduced a bug, this is the fix. Even if the `reader.Read()` returns an error it also returns the slice of strings, so we've to continue the sequence.

With this change all the tests are green again.